### PR TITLE
Clarify MobileFormatter serialization limitations for collections

### DIFF
--- a/csla-examples/CustomSerializers.md
+++ b/csla-examples/CustomSerializers.md
@@ -179,7 +179,8 @@ The `SerializationInfo` class can store the following "primitive" types:
 - `Guid`
 - `byte[]`
 - `char[]`
-- `List<int>` (and other primitive type lists)
+
+> ⚠️ Standard .NET collection types such as `List<T>` and `Dictionary<K,V>` are _not_ directly serializable by `MobileFormatter`. Use `MobileList<T>` or `MobileDictionary<K,V>` from `Csla.Core` for serializable collections, or register a custom serializer for your collection type.
 
 ## Common Scenarios
 

--- a/csla-examples/v10/CustomSerializers.md
+++ b/csla-examples/v10/CustomSerializers.md
@@ -97,9 +97,10 @@ The `SerializationInfo` class can store these primitive types:
 | Text | `string`, `char`, `char[]` |
 | Boolean | `bool` |
 | Date/Time | `DateTime`, `DateTimeOffset`, `TimeSpan`, `DateOnly`, `TimeOnly` |
-| Other | `Guid`, `byte[]` |
-| Collections | `List<T>` of primitive types |
+| Other | `Guid`, `byte[]`, `char[]` |
 | Nullable | Nullable versions of all above types |
+
+> ⚠️ Standard .NET collection types such as `List<T>` and `Dictionary<K,V>` are _not_ directly serializable by `MobileFormatter`. Use `MobileList<T>` or `MobileDictionary<K,V>` from `Csla.Core` for serializable collections, or register a custom serializer for your collection type.
 
 For complex types, serialize them as JSON strings or implement child object handling.
 

--- a/csla-examples/v9/PocoSerialization.md
+++ b/csla-examples/v9/PocoSerialization.md
@@ -242,8 +242,9 @@ The `SerializationInfo` class can store these "primitive" types directly:
 - `Guid`
 - `byte[]`
 - `char[]`
-- `List<int>` (and other primitive type lists)
 - Nullable versions of the above types
+
+> ⚠️ Standard .NET collection types such as `List<T>` and `Dictionary<K,V>` are _not_ directly serializable by `MobileFormatter`. Use `MobileList<T>` or `MobileDictionary<K,V>` from `Csla.Core` for serializable collections, or register a custom serializer for your collection type.
 
 For complex types (objects, lists of objects), use the child object methods.
 


### PR DESCRIPTION
## Summary
Updated documentation across multiple versions to clarify that standard .NET collection types (`List<T>`, `Dictionary<K,V>`) are not directly serializable by `MobileFormatter`, and provide guidance on proper alternatives.

## Key Changes
- Removed misleading references to `List<T>` as a supported primitive type in serialization documentation
- Added prominent warning notices in three documentation files explaining that standard .NET collections require either:
  - Use of CSLA-specific alternatives (`MobileList<T>`, `MobileDictionary<K,V>` from `Csla.Core`)
  - Custom serializer registration
- Reorganized the "Other" types section to clarify `char[]` is supported as a primitive type
- Applied consistent documentation updates across v9, v10, and main documentation branches

## Notable Details
- The changes address a common source of confusion where developers might assume standard .NET collections work with `MobileFormatter`
- Warning notices use consistent formatting and messaging across all affected documentation files
- No functional code changes; documentation-only updates to improve clarity and prevent misuse

https://claude.ai/code/session_011R3Y2CSgCZrDwdVacjARaW